### PR TITLE
末尾カンマを除去しました

### DIFF
--- a/docs/vpm.json
+++ b/docs/vpm.json
@@ -17,7 +17,7 @@
 						"Assets\\whiteflare\\AvatarCopyUtility": "3b97d7763e106a84085cabe264b91502",
 						"Assets\\whiteflare\\AvatarTexTool": "957ff4a0e9b0a2b4bb5cd5f99498272b",
 						"Assets\\whiteflare\\BoundsUnificator": "e202e341b570b8c4dab04b735bd3feb8",
-						"Assets\\whiteflare\\HierarchyHelper": "97e98175714db7e46b162eb0b12142f7",
+						"Assets\\whiteflare\\HierarchyHelper": "97e98175714db7e46b162eb0b12142f7"
 					},
 					"legacyFiles": {
 						"Assets\\whiteflare\\MiscTools\\Editor\\MeshPolyCounter.cs": "8f7ca49ca853c214db6ff6cff7958ac6"


### PR DESCRIPTION
末尾カンマがあるとJSONのパーサーでうまくパースできないため、末尾カンマを除去しました。